### PR TITLE
refactor!: Include function source when given a function

### DIFF
--- a/R/btw_this.R
+++ b/R/btw_this.R
@@ -151,20 +151,11 @@ btw_this.Chat <- function(x, ...) {
 
 #' @export
 btw_this.function <- function(x, ...) {
-  x_text <- deparse(substitute(x))
-  if (is_namespace(fn_env(x))) {
-    # packaged function
-    package <- sub(
-      "namespace:",
-      "",
-      env_name(fn_env(x)),
-      fixed = TRUE
-    )
-    fn_name <- sub("^([^:]*::)?", "", x_text)
-    return(btw_this(as_btw_docs_topic(package, fn_name)))
-  }
+  fn_def <- capture.output(print(x))
 
-  strsplit(expr_text(fn_body(x), width = 80), "\n")[[1]]
+  fn_def <- fn_def[!grepl("^<(bytecode|environment): ", fn_def)]
+
+  md_code_block("r", fn_def)
 }
 
 #' @export

--- a/R/tool-environment.R
+++ b/R/tool-environment.R
@@ -69,10 +69,6 @@ btw_tool_describe_environment <- function(
       }
     }
 
-    if (is_function(item) && is_namespace(fn_env(item))) {
-      item <- paste0("?", item_name)
-    }
-
     btw_this(item, caller_env = environment)
   })
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -45,8 +45,9 @@ library(btw)
 
 The `btw()` function allows you to compile information about all sorts of R stuff and copy it to your clipboard.
 
-* Pass any R object to `btw()`, like `btw(mtcars)`, `btw(dplyr::across)` or `btw(globalenv())`. Strings will be evaluated as R code and dispatched to the appropriate method unless they match a shortcut described below.
+* Pass any R object to `btw()`, like `btw(mtcars)`, `btw(dplyr::across)` or `btw(globalenv())`.
 * `btw("{dplyr}")` will describe the dplyr package via the function reference and (if available) introductory vignette.
+* `btw("?dplyr::across")` or `btw(?dplyr::across)` includes the help pages for `dplyr::across()`.
 * `btw("./path")` will read the lines of the file at that path (or list the files at that path if it's a directory).
 * `btw("@current_file")` and `btw("@current_selection")` reads the contents of the current editor or selection in RStudio, Positron, or anywhere the [rstudioapi](https://rstudio.github.io/rstudioapi) is supported.
 
@@ -54,7 +55,7 @@ When passed multiple arguments, `btw()` will concatenate each description. For e
 
 ```{r}
 #| eval: false
-btw(mtcars, "{btw}", btw::btw)
+btw(mtcars, "{btw}", ?btw::btw)
 ```
 
 ```
@@ -66,7 +67,7 @@ The following would be attached to your clipboard:
 ```{r}
 #| comment: ""
 #| echo: false
-cli::cat_line(btw(mtcars, "{btw}", btw::btw))
+cli::cat_line(btw(mtcars, "{btw}", ?btw::btw))
 ```
 
 You can also just call `btw()` with no inputs, which will describe the objects in your global environment.
@@ -126,7 +127,7 @@ Given the data shown in the context, this will include cars with 4 and 6
 cylinders (as the `cyl` column only contains values 4, 6, and 8).
 ````
 
-`btw_client()` uses `ellmer::chat_claude()` by default, or you can customize the chat client used in one of two ways: 
+`btw_client()` uses `ellmer::chat_claude()` by default, or you can customize the chat client used in one of two ways:
 
 * Set the `btw.chat_client` option (possibly in your `.Rprofile` with `usethis::edit_r_profile()`), or
 * Provide your own chat object via the `client` argument.
@@ -141,6 +142,6 @@ ch <- btw_client()
 ch <- btw_client(client = ellmer::chat_ollama(model = "llama3.1:8b"))
 ```
 
-Alternatively, you can call `btw_app()` to jump straight into a Shiny chat app. 
+Alternatively, you can call `btw_app()` to jump straight into a Shiny chat app.
 
 For fully customized chat clients, you can use `btw_register_tools()` to add btw tools to an existing chat interface. Each of the individual tools registered by `btw_register_tools()` are themselves exported, and can be selected via the `include` argument of `btw_register_tools()` (`include` is also available in `btw_client()` or `btw_app()`).

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ The `btw()` function allows you to compile information about all sorts
 of R stuff and copy it to your clipboard.
 
 - Pass any R object to `btw()`, like `btw(mtcars)`, `btw(dplyr::across)`
-  or `btw(globalenv())`. Strings will be evaluated as R code and
-  dispatched to the appropriate method unless they match a shortcut
-  described below.
+  or `btw(globalenv())`.
 - `btw("{dplyr}")` will describe the dplyr package via the function
   reference and (if available) introductory vignette.
+- `btw("?dplyr::across")` or `btw(?dplyr::across)` includes the help
+  pages for `dplyr::across()`.
 - `btw("./path")` will read the lines of the file at that path (or list
   the files at that path if it’s a directory).
 - `btw("@current_file")` and `btw("@current_selection")` reads the
@@ -62,7 +62,7 @@ When passed multiple arguments, `btw()` will concatenate each
 description. For example, you could run:
 
 ``` r
-btw(mtcars, "{btw}", btw::btw)
+btw(mtcars, "{btw}", ?btw::btw)
 ```
 
     ✔ btw copied to the clipboard!
@@ -97,7 +97,7 @@ The following would be attached to your clipboard:
     ]
     ```
 
-    btw::btw
+    `?`(btw::btw)
     btw                    package:btw                     R Documentation
 
     Plain-text descriptions of R objects

--- a/tests/testthat/_snaps/btw_this.md
+++ b/tests/testthat/_snaps/btw_this.md
@@ -1,0 +1,12 @@
+# btw_this.function()
+
+    Code
+      cli::cat_line(btw_this(dplyr::mutate))
+    Output
+      ```r
+      function (.data, ...) 
+      {
+          UseMethod("mutate")
+      }
+      ```
+

--- a/tests/testthat/test-btw_this.R
+++ b/tests/testthat/test-btw_this.R
@@ -1,12 +1,6 @@
 test_that("btw_this.function()", {
-  expect_equal(btw_this('?dplyr::mutate'), btw_this(dplyr::mutate))
-})
-
-test_that("btw() with package functions", {
-  expect_equal(
-    sub("dplyr::mutate", '"?dplyr::mutate"', format(btw(dplyr::mutate))),
-    format(btw('?dplyr::mutate'))
-  )
+  skip_if_not_macos()
+  expect_snapshot(cli::cat_line(btw_this(dplyr::mutate)))
 })
 
 test_that("btw_this('{pkg}')", {


### PR DESCRIPTION
This is another API contraction, but in the end I think it's worth it. Previously, these would all include the help pages for a function:

```r
btw(sessioninfo::platform_info)
btw(?sessioninfo::platform_info)
btw("?sessioninfo::platform_info")
```

But what if you wanted to include the function source in the btw context?

After considering a few approaches, I think it's best if we simplify `btw_this.function()` so that it always includes the function source and require the `?` approach for help pages.

```r
# Includes the source of `platform_info()`
btw(sessioninfo::platform_info)

# Includes the help pages
btw(?sessioninfo::platform_info)
btw("?sessioninfo::platform_info")

# Includes both
btw(?sessioninfo::platform_info, sessioninfo::platform_info)
```