### PR TITLE
feat: `@last_error` and `@last_value`

### DIFF
--- a/R/btw_this.R
+++ b/R/btw_this.R
@@ -99,6 +99,10 @@ as_btw_capture <- function(x) {
 #'   To reliably capture the last error, you need to enable
 #'   [rlang::global_entrace()] in your session.
 #'
+#' * `"@last_value"` \cr
+#'   Includes the `.Last.value`, i.e. the result of the last expression
+#'   evaluated in your R console.
+#'
 #' @param x A character string
 #' @param ... Ignored.
 #' @param caller_env The caller environment.
@@ -134,6 +138,9 @@ btw_this.character <- function(x, ..., caller_env = parent.frame()) {
     return(
       if (is.null(err)) btw_ignore() else capture_print(err)
     )
+  }
+  if (identical(x, "@last_value")) {
+    return(btw_this(get_last_value()))
   }
 
   if (grepl("^\\./", x)) {
@@ -286,4 +293,8 @@ get_last_error <- function() {
     ))
   }
   err
+}
+
+get_last_value <- function() {
+  base::.Last.value
 }

--- a/R/btw_this.R
+++ b/R/btw_this.R
@@ -28,6 +28,8 @@ btw_this.default <- function(x, ...) {
 
 capture_print <- function(x) {
   # TODO: Replace with {evaluate}
+  local_reproducible_output(max.print = 100)
+
   out <- capture.output(print(x))
   if (length(out) == 0 || !any(nzchar(out))) {
     out <- capture.output(print(x), type = "message")
@@ -37,6 +39,7 @@ capture_print <- function(x) {
 }
 
 as_btw_capture <- function(x) {
+  x <- cli::ansi_strip(x)
   structure(x, class = c("btw_captured", "character"))
 }
 

--- a/R/tool-environment.R
+++ b/R/tool-environment.R
@@ -147,6 +147,7 @@ btw_item_with_description <- function(item_name, description, header = NULL) {
     item_name <- switch(
       item_name,
       "@last_error" = "last_error()",
+      "@last_value" = ".Last.value",
       item_name
     )
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -56,3 +56,31 @@ path_find_in_project <- function(filename, dir = getwd()) {
 
   path_find_in_project(filename, dirname(dir))
 }
+
+local_reproducible_output <- function(
+  width = 80L,
+  max.print = 100,
+  .env = parent.frame()
+) {
+  # Replicating testthat::local_reproducible_output()
+  withr::local_options(width = width, cli.width = width, .local_envir = .env)
+  withr::local_envvar(RSTUDIO_CONSOLE_WIDTH = width, .local_envir = .env)
+  withr::local_envvar(list(NO_COLOR = "true"), .local_envir = .env)
+  withr::local_options(
+    crayon.enabled = FALSE,
+    cli.hyperlink = FALSE,
+    cli.hyperlink_run = FALSE,
+    cli.hyperlink_help = FALSE,
+    cli.hyperlink_vignette = FALSE,
+    cli.dynamic = FALSE,
+    cli.unicode = FALSE,
+    cli.condition_width = Inf,
+    cli.num_colors = 1L,
+    useFancyQuotes = FALSE,
+    lifecycle_verbosity = "warning",
+    OutDec = ".",
+    rlang_interactive = FALSE,
+    max.print = max.print,
+    .local_envir = .env
+  )
+}

--- a/README.Rmd
+++ b/README.Rmd
@@ -52,6 +52,7 @@ The `btw()` function allows you to compile information about all sorts of R stuf
 * `btw("@current_file")` and `btw("@current_selection")` reads the contents of the current editor or selection in RStudio, Positron, or anywhere the [rstudioapi](https://rstudio.github.io/rstudioapi) is supported.
 * `btw("@platform_info")` describes your R version, operating system, and locale information.
 * `btw()` with `"@attached_packages"`, `"@loaded_packages"`, or `"@installed_packages"` includes a listing of attached (i.e. with `library()`), loaded (in use in the session, often indirectly), or installed packages.
+* And more! See `?btw_this.character` for the full list of additional context strings.
 
 When passed multiple arguments, `btw()` will concatenate each description. For example, you could run:
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ of R stuff and copy it to your clipboard.
   `"@installed_packages"` includes a listing of attached (i.e. with
   `library()`), loaded (in use in the session, often indirectly), or
   installed packages.
+- And more! See `?btw_this.character` for the full list of additional
+  context strings.
 
 When passed multiple arguments, `btw()` will concatenate each
 description. For example, you could run:
@@ -95,7 +97,6 @@ The following would be attached to your clipboard:
       {"topic_id":"btw_this.environment","title":"Describe the contents of an environment","aliases":["btw_this.environment"]},
       {"topic_id":"btw_tool_describe_data_frame","title":"Tool: Describe data frame","aliases":["btw_tool_describe_data_frame"]},
       {"topic_id":"btw_tool_describe_environment","title":"Tool: Describe an environment","aliases":["btw_tool_describe_environment"]},
-      {"topic_id":"btw_tool_get_installed_packages","title":"Tool: Describe installed packages","aliases":["btw_tool_get_installed_packages"]},
       {"topic_id":"btw_tool_list_files","title":"Tool: List files","aliases":["btw_tool_list_files"]},
       {"topic_id":"btw_tool_package_docs","title":"Tool: Describe R package documentation","aliases":["btw_tool_package_docs","btw_tool_get_package_help_topics","btw_tool_get_help_page","btw_tool_get_available_vignettes_in_package","btw_tool_get_vignette_from_package"]},
       {"topic_id":"btw_tool_read_current_editor","title":"Tool: Read current file","aliases":["btw_tool_read_current_editor"]},

--- a/man/btw_this.character.Rd
+++ b/man/btw_this.character.Rd
@@ -62,6 +62,10 @@ timezone and current date.
 \item \code{"@attached_packages"}, \code{"@loaded_packages"}, \code{"@installed_packages"} \cr
 Includes information about the attached, loaded, or installed packages in
 your R session, using \code{\link[sessioninfo:package_info]{sessioninfo::package_info()}}.
+\item \code{"@last_error"} \cr
+Includes the message from the last error that occurred in your session.
+To reliably capture the last error, you need to enable
+\code{\link[rlang:global_entrace]{rlang::global_entrace()}} in your session.
 }
 }
 \seealso{

--- a/man/btw_this.character.Rd
+++ b/man/btw_this.character.Rd
@@ -66,6 +66,9 @@ your R session, using \code{\link[sessioninfo:package_info]{sessioninfo::package
 Includes the message from the last error that occurred in your session.
 To reliably capture the last error, you need to enable
 \code{\link[rlang:global_entrace]{rlang::global_entrace()}} in your session.
+\item \code{"@last_value"} \cr
+Includes the \code{.Last.value}, i.e. the result of the last expression
+evaluated in your R console.
 }
 }
 \seealso{

--- a/tests/testthat/_snaps/btw_this.md
+++ b/tests/testthat/_snaps/btw_this.md
@@ -10,3 +10,10 @@
       }
       ```
 
+# btw_this('@last_error')
+
+    Code
+      cat(btw_this("@last_error"))
+    Output
+      <error/rlang_error> Error: ! That didn't work.
+

--- a/tests/testthat/test-btw_this.R
+++ b/tests/testthat/test-btw_this.R
@@ -30,3 +30,23 @@ test_that("btw_this() handles literal strings", {
     "letters[3]"
   )
 })
+
+test_that("btw_this('@last_error')", {
+  with_mocked_bindings(
+    last_error = function() {
+      stop(
+        "Can't show last error because no error was recorded yet",
+        call. = FALSE
+      )
+    },
+    expect_warning(expect_equal(btw_this("@last_error"), btw_ignore()))
+  )
+
+  with_mocked_bindings(
+    last_error = function() {
+      rlang::catch_cnd(abort("That didn't work.", trace = FALSE, call = NULL))
+    },
+    # btw_this("@last_error")
+    expect_snapshot(cat(btw_this("@last_error")))
+  )
+})

--- a/tests/testthat/test-btw_this.R
+++ b/tests/testthat/test-btw_this.R
@@ -50,3 +50,14 @@ test_that("btw_this('@last_error')", {
     expect_snapshot(cat(btw_this("@last_error")))
   )
 })
+
+test_that('btw_this("@last_value")', {
+  local_mocked_bindings(
+    get_last_value = function() mtcars[2:4, ]
+  )
+
+  expect_equal(
+    btw_this("@last_value"),
+    btw_this(mtcars[2:4, ])
+  )
+})


### PR DESCRIPTION
Fixes #32: adds support for `btw("@last_error")` and `btw("@last_value")`.

I'm not including either as a tool because I think it's more likely to cause confusion, e.g. if a tool call fails the model might think `@last_error` is an appropriate tool to call to get help. Similarly, `@last_value` only makes sense if the app is run in the same session as the interactive console, which isn't likely or easy.

I'm also not including `"@last_warnings"` or `"@last_messages"`, because I don't think they'd be as useful, but I'm open to the idea.