### PR TITLE
feat!: Use `btw.md` instead of `.btw`

### DIFF
--- a/R/btw_client.R
+++ b/R/btw_client.R
@@ -10,30 +10,31 @@
 #' ## Project Context
 #'
 #' You can keep track of project-specific rules, guidance and context by adding
-#' a `.btw` file in your project directory. Any time you start a chat client
+#' a `btw.md` file in your project directory. Any time you start a chat client
 #' with `btw_client()` or launch a chat session with `btw_app()`, btw will
-#' automatically find and include the contents of the `.btw` file in your chat.
+#' automatically find and include the contents of the `btw.md` file in your
+#' chat.
 #'
-#' Use the `.btw` file to inform the LLM of your preferred code style, to
-#' provide domain-specific terminology or definitions, to establish project
+#' Use `btw.md` to inform the LLM of your preferred code style, to provide
+#' domain-specific terminology or definitions, to establish project
 #' documentation, goals and constraints, to include reference materials such or
-#' technical specifications, or more. Storing this kind of information in the
-#' `.btw` file may help you avoid repeating yourself and can be used to maintain
+#' technical specifications, or more. Storing this kind of information in
+#' `btw.md` may help you avoid repeating yourself and can be used to maintain
 #' coherence across many chat sessions.
 #'
-#' The `.btw` file, when present, is included as part of the system prompt for
+#' The `btw.md` file, when present, is included as part of the system prompt for
 #' your chat conversation. You can structure the file in any way you wish.
 #'
-#' You can also use the `.btw` file to choose default chat settings for your
+#' You can also use the `btw.md` file to choose default chat settings for your
 #' project in a YAML block at the top of the file. In this YAML block you can
 #' choose the default `provider`, `model` and `tools` for `btw_client()` or
 #' `btw_app()`. `provider` chooses the `ellmer::chat_*()` function, e.g.
 #' `provider: openai` or `provider: chat_openai` to use [ellmer::chat_openai()].
 #' `tools` chooses which btw tools are included in the chat, and all other
-#' values are passed to the `ellmer::chat_*()` constructor, e.g.
-#' `model: gpt-4o`, `seed: 42`, or `echo: all``.
+#' values are passed to the `ellmer::chat_*()` constructor, e.g. `model:
+#' gpt-4o`, `seed: 42`, or `echo: all``.
 #'
-#' Here's an example `.btw` file:
+#' Here's an example `btw.md` file:
 #'
 #' ````
 #' ---
@@ -71,18 +72,18 @@
 #'   via [btw()].
 #' @param client An [ellmer::Chat] client, defaults to [ellmer::chat_claude()].
 #'   You can use the `btw.chat_client` option to set a default client for new
-#'   `btw_client()` calls, or use a `.btw` project file for default chat client
-#'   settings, like provider and model. We check the `client` argument, then the
-#'   `btw.chat_client` R option, and finally the `.btw` project file, using only
-#'   the client definition from the first of these that is available.
+#'   `btw_client()` calls, or use a `btw.md` project file for default chat
+#'   client settings, like provider and model. We check the `client` argument,
+#'   then the `btw.chat_client` R option, and finally the `btw.md` project file,
+#'   using only the client definition from the first of these that is available.
 #' @param tools Names of tools or tool groups to include when registering
 #'   tools, e.g. `include = "docs"` to include only the documentation related
 #'   tools, or `include = c("data", "docs", "environment")`, etc. Equivalent to
 #'   the `include` argument of [btw_register_tools()]. Use `tools = FALSE` to
 #'   skip registering \pkg{btw} tools with the chat client.
-#' @param path_btw A path to a `.btw` project context file. If `NULL`, btw will
-#'   find a project-specific `.btw` file in the parents of the current working
-#'   directory.
+#' @param path_btw A path to a `btw.md` project context file. If `NULL`, btw
+#'   will find a project-specific `btw.md` file in the parents of the current
+#'   working directory.
 #'
 #' @return Returns an [ellmer::Chat] object with additional tools registered by
 #'   [btw_register_tools()]. `btw_app()` returns the chat object invisibly, and
@@ -209,7 +210,7 @@ btw_client_config <- function(client = NULL, tools = NULL, config = list()) {
 read_btw_file <- function(path = NULL) {
   must_find <- !is.null(path)
 
-  path <- path %||% path_find_in_project(".btw")
+  path <- path %||% path_find_in_project("btw.md")
 
   if (!must_find && is.null(path)) {
     return(list())

--- a/man/btw_client.Rd
+++ b/man/btw_client.Rd
@@ -15,10 +15,10 @@ via \code{\link[=btw]{btw()}}.}
 
 \item{client}{An \link[ellmer:Chat]{ellmer::Chat} client, defaults to \code{\link[ellmer:chat_claude]{ellmer::chat_claude()}}.
 You can use the \code{btw.chat_client} option to set a default client for new
-\code{btw_client()} calls, or use a \code{.btw} project file for default chat client
-settings, like provider and model. We check the \code{client} argument, then the
-\code{btw.chat_client} R option, and finally the \code{.btw} project file, using only
-the client definition from the first of these that is available.}
+\code{btw_client()} calls, or use a \code{btw.md} project file for default chat
+client settings, like provider and model. We check the \code{client} argument,
+then the \code{btw.chat_client} R option, and finally the \code{btw.md} project file,
+using only the client definition from the first of these that is available.}
 
 \item{tools}{Names of tools or tool groups to include when registering
 tools, e.g. \code{include = "docs"} to include only the documentation related
@@ -26,9 +26,9 @@ tools, or \code{include = c("data", "docs", "environment")}, etc. Equivalent to
 the \code{include} argument of \code{\link[=btw_register_tools]{btw_register_tools()}}. Use \code{tools = FALSE} to
 skip registering \pkg{btw} tools with the chat client.}
 
-\item{path_btw}{A path to a \code{.btw} project context file. If \code{NULL}, btw will
-find a project-specific \code{.btw} file in the parents of the current working
-directory.}
+\item{path_btw}{A path to a \code{btw.md} project context file. If \code{NULL}, btw
+will find a project-specific \code{btw.md} file in the parents of the current
+working directory.}
 }
 \value{
 Returns an \link[ellmer:Chat]{ellmer::Chat} object with additional tools registered by
@@ -44,30 +44,30 @@ local workspace.
 \subsection{Project Context}{
 
 You can keep track of project-specific rules, guidance and context by adding
-a \code{.btw} file in your project directory. Any time you start a chat client
+a \code{btw.md} file in your project directory. Any time you start a chat client
 with \code{btw_client()} or launch a chat session with \code{btw_app()}, btw will
-automatically find and include the contents of the \code{.btw} file in your chat.
+automatically find and include the contents of the \code{btw.md} file in your
+chat.
 
-Use the \code{.btw} file to inform the LLM of your preferred code style, to
-provide domain-specific terminology or definitions, to establish project
+Use \code{btw.md} to inform the LLM of your preferred code style, to provide
+domain-specific terminology or definitions, to establish project
 documentation, goals and constraints, to include reference materials such or
-technical specifications, or more. Storing this kind of information in the
-\code{.btw} file may help you avoid repeating yourself and can be used to maintain
+technical specifications, or more. Storing this kind of information in
+\code{btw.md} may help you avoid repeating yourself and can be used to maintain
 coherence across many chat sessions.
 
-The \code{.btw} file, when present, is included as part of the system prompt for
+The \code{btw.md} file, when present, is included as part of the system prompt for
 your chat conversation. You can structure the file in any way you wish.
 
-You can also use the \code{.btw} file to choose default chat settings for your
+You can also use the \code{btw.md} file to choose default chat settings for your
 project in a YAML block at the top of the file. In this YAML block you can
 choose the default \code{provider}, \code{model} and \code{tools} for \code{btw_client()} or
 \code{btw_app()}. \code{provider} chooses the \verb{ellmer::chat_*()} function, e.g.
 \code{provider: openai} or \code{provider: chat_openai} to use \code{\link[ellmer:chat_openai]{ellmer::chat_openai()}}.
 \code{tools} chooses which btw tools are included in the chat, and all other
-values are passed to the \verb{ellmer::chat_*()} constructor, e.g.
-\verb{model: gpt-4o}, \code{seed: 42}, or `echo: all``.
+values are passed to the \verb{ellmer::chat_*()} constructor, e.g. \verb{model: gpt-4o}, \code{seed: 42}, or `echo: all``.
 
-Here's an example \code{.btw} file:
+Here's an example \code{btw.md} file:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{---
 provider: claude

--- a/tests/testthat/_snaps/btw_client.md
+++ b/tests/testthat/_snaps/btw_client.md
@@ -33,7 +33,7 @@
       
       I like to have my own system prompt.
 
-# btw_client() adds `.btw` context file to system prompt
+# btw_client() adds `btw.md` context file to system prompt
 
     Code
       print(chat)
@@ -74,7 +74,7 @@
       
       I like to have my own system prompt.
 
-# btw_client() uses `.btw` context file for client settings
+# btw_client() uses `btw.md` context file for client settings
 
     Code
       print(chat)

--- a/tests/testthat/test-btw_client.R
+++ b/tests/testthat/test-btw_client.R
@@ -47,7 +47,7 @@ test_that("btw_client() modifies `client` argument in place", {
   expect_identical(chat, client)
 })
 
-test_that("btw_client() adds `.btw` context file to system prompt", {
+test_that("btw_client() adds `btw.md` context file to system prompt", {
   withr::local_envvar(list(ANTHROPIC_API_KEY = "beep"))
 
   wd <- withr::local_tempdir(
@@ -56,7 +56,7 @@ test_that("btw_client() adds `.btw` context file to system prompt", {
   withr::local_dir(wd)
 
   writeLines(
-    con = file.path(wd, "..", ".btw"),
+    con = file.path(wd, "..", "btw.md"),
     c(
       "* Prefer solutions that use {tidyverse}",
       "* Always use `=` for assignment",
@@ -83,7 +83,7 @@ test_that("btw_client() adds `.btw` context file to system prompt", {
   expect_snapshot(print(chat), transform = scrub_system_info)
 })
 
-test_that("btw_client() uses `.btw` context file for client settings", {
+test_that("btw_client() uses `btw.md` context file for client settings", {
   withr::local_envvar(list(OPENAI_API_KEY = "beep"))
 
   wd <- withr::local_tempdir(
@@ -92,7 +92,7 @@ test_that("btw_client() uses `.btw` context file for client settings", {
   withr::local_dir(wd)
 
   writeLines(
-    con = file.path(wd, "..", ".btw"),
+    con = file.path(wd, "..", "btw.md"),
     c(
       "---",
       "provider: openai",
@@ -124,7 +124,7 @@ test_that("btw_client() uses `.btw` context file for client settings", {
     fixed = TRUE
   )
 
-  fs::file_move("../.btw", "../btw-context.md")
+  fs::file_move("../btw.md", "../btw-context.md")
   with_mocked_platform(ide = "rstudio", {
     chat_parent <-
       btw_client(path_btw = "../btw-context.md")


### PR DESCRIPTION
Breaking change to use `btw.md` instead of `.btw`.

`.btw` is too hidden, it's a markdown file, `btw.md` follows `claude.md`, we might use `.btw/` for other things, etc etc etc