### PR TITLE
chore: Rename `btw.client` and `btw.tools` options

### DIFF
--- a/R/btw_client.R
+++ b/R/btw_client.R
@@ -53,15 +53,15 @@
 #'
 #' ## Client Options
 #'
-#' * `btw.chat_client`: The [ellmer::Chat] client to use as the basis for new
+#' * `btw.client`: The [ellmer::Chat] client to use as the basis for new
 #'   `btw_client()` or `btw_app()` chats.
-#' * `btw.chat_tools`: The btw tools to include by default when starting a new
+#' * `btw.tools`: The btw tools to include by default when starting a new
 #'   btw chat, see [btw_register_tools()] for details.
 #'
 #' @examples
 #' if (interactive()) {
 #'   withr::local_options(list(
-#'     btw.chat_client = ellmer::chat_ollama(model="llama3.1:8b")
+#'     btw.client = ellmer::chat_ollama(model="llama3.1:8b")
 #'   ))
 #'
 #'   chat <- btw_client()
@@ -71,10 +71,10 @@
 #' @param ... Objects and documentation to be included as context in the chat,
 #'   via [btw()].
 #' @param client An [ellmer::Chat] client, defaults to [ellmer::chat_claude()].
-#'   You can use the `btw.chat_client` option to set a default client for new
+#'   You can use the `btw.client` option to set a default client for new
 #'   `btw_client()` calls, or use a `btw.md` project file for default chat
 #'   client settings, like provider and model. We check the `client` argument,
-#'   then the `btw.chat_client` R option, and finally the `btw.md` project file,
+#'   then the `btw.client` R option, and finally the `btw.md` project file,
 #'   using only the client definition from the first of these that is available.
 #' @param tools Optional names of tools or tool groups to include in the chat
 #'   client. By default, all btw tools are included. For example, use
@@ -173,7 +173,7 @@ btw_app <- function(..., client = NULL, tools = NULL, path_btw = NULL) {
 btw_client_config <- function(client = NULL, tools = NULL, config = list()) {
   config$tools <-
     tools %||%
-    getOption("btw.chat_tools") %||%
+    getOption("btw.tools") %||%
     config$tools
 
   if (!is.null(client)) {
@@ -182,7 +182,7 @@ btw_client_config <- function(client = NULL, tools = NULL, config = list()) {
     return(config)
   }
 
-  default <- getOption("btw.chat_client")
+  default <- getOption("btw.client")
   if (!is.null(default)) {
     check_inherits(default, "Chat")
     config$client <- default$clone()

--- a/man/btw_client.Rd
+++ b/man/btw_client.Rd
@@ -14,10 +14,10 @@ btw_app(..., client = NULL, tools = NULL, path_btw = NULL)
 via \code{\link[=btw]{btw()}}.}
 
 \item{client}{An \link[ellmer:Chat]{ellmer::Chat} client, defaults to \code{\link[ellmer:chat_claude]{ellmer::chat_claude()}}.
-You can use the \code{btw.chat_client} option to set a default client for new
+You can use the \code{btw.client} option to set a default client for new
 \code{btw_client()} calls, or use a \code{btw.md} project file for default chat
 client settings, like provider and model. We check the \code{client} argument,
-then the \code{btw.chat_client} R option, and finally the \code{btw.md} project file,
+then the \code{btw.client} R option, and finally the \code{btw.md} project file,
 using only the client definition from the first of these that is available.}
 
 \item{tools}{Optional names of tools or tool groups to include in the chat
@@ -86,9 +86,9 @@ Follow these important style rules for any R code in this project:
 
 \subsection{Client Options}{
 \itemize{
-\item \code{btw.chat_client}: The \link[ellmer:Chat]{ellmer::Chat} client to use as the basis for new
+\item \code{btw.client}: The \link[ellmer:Chat]{ellmer::Chat} client to use as the basis for new
 \code{btw_client()} or \code{btw_app()} chats.
-\item \code{btw.chat_tools}: The btw tools to include by default when starting a new
+\item \code{btw.tools}: The btw tools to include by default when starting a new
 btw chat, see \code{\link[=btw_register_tools]{btw_register_tools()}} for details.
 }
 }
@@ -104,7 +104,7 @@ chat
 \examples{
 if (interactive()) {
   withr::local_options(list(
-    btw.chat_client = ellmer::chat_ollama(model="llama3.1:8b")
+    btw.client = ellmer::chat_ollama(model="llama3.1:8b")
   ))
 
   chat <- btw_client()

--- a/tests/testthat/_snaps/btw_client.md
+++ b/tests/testthat/_snaps/btw_client.md
@@ -1,4 +1,4 @@
-# btw_client() works with `btw.chat_client` option
+# btw_client() works with `btw.client` option
 
     Code
       print(chat)

--- a/tests/testthat/test-btw_client.R
+++ b/tests/testthat/test-btw_client.R
@@ -1,8 +1,8 @@
-test_that("btw_client() works with `btw.chat_client` option", {
+test_that("btw_client() works with `btw.client` option", {
   withr::local_envvar(list(ANTHROPIC_API_KEY = "beep"))
 
   local_options(
-    btw.chat_client = ellmer::chat_claude(
+    btw.client = ellmer::chat_claude(
       system_prompt = "I like to have my own system prompt."
     )
   )
@@ -14,7 +14,7 @@ test_that("btw_client() works with `btw.chat_client` option", {
   expect_match(chat$get_system_prompt(), "I like to have my own system prompt")
   expect_match(chat$get_system_prompt(), "You have access to tools")
   expect_no_match(
-    getOption("btw.chat_client")$get_system_prompt(),
+    getOption("btw.client")$get_system_prompt(),
     "You have access to tools"
   )
 


### PR DESCRIPTION
Simplifies names, avoids extra "chat_" prefix

* `btw.chat_client` → `btw.client`
* `btw.chat_tools` → `btw.tools`