### PR TITLE
feat: Package docs as markdown

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,7 @@ Suggests:
     testthat (>= 3.0.0)
 Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
+Config/testthat/parallel: true
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,11 +35,12 @@ Imports:
     tibble,
     withr
 Suggests:
+    pandoc,
     testthat (>= 3.0.0)
 Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
-Remotes:  
+Remotes: 
     tidyverse/ellmer

--- a/R/tool-docs.R
+++ b/R/tool-docs.R
@@ -91,6 +91,8 @@ btw_tool_docs_help_page <- function(topic, package_name = "") {
     check_installed(package_name)
   }
 
+  withr::local_options(list(menu.graphics = FALSE))
+
   help_page <- inject(help(
     package = !!package_name,
     topic = !!topic,

--- a/R/tool-docs.R
+++ b/R/tool-docs.R
@@ -190,15 +190,7 @@ btw_tool_docs_vignette <- function(
     )
   }
 
-  tmp_file <- withr::local_tempfile(fileext = ".md")
-  rmarkdown::pandoc_convert(
-    file.path(vignette_info$Dir, "doc", vignette_info$PDF),
-    from = "html",
-    to = "markdown",
-    output = tmp_file
-  )
-
-  readLines(tmp_file)
+  pandoc_convert(file.path(vignette_info$Dir, "doc", vignette_info$PDF))
 }
 
 .btw_add_to_tools(

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,3 +1,17 @@
+pandoc_convert <- function(path, ..., from = "html", to = "markdown") {
+  tmp_file <- withr::local_tempfile()
+
+  rmarkdown::pandoc_convert(
+    path,
+    from = from,
+    to = to,
+    output = tmp_file,
+    ...
+  )
+
+  readLines(tmp_file)
+}
+
 # ad-hoc check functions ------------------------------------------------------
 check_inherits <- function(
   x,

--- a/tests/testthat/_snaps/tool-docs.md
+++ b/tests/testthat/_snaps/tool-docs.md
@@ -1,140 +1,137 @@
 # btw_tool_docs_help_page() works
 
     Code
-      res
+      cli::cat_line(res)
     Output
-        [1] "Normal                  package:stats                  R Documentation"  
-        [2] ""                                                                        
-        [3] "The Normal Distribution"                                                 
-        [4] ""                                                                        
-        [5] "Description:"                                                            
-        [6] ""                                                                        
-        [7] "     Density, distribution function, quantile function and random"       
-        [8] "     generation for the normal distribution with mean equal to 'mean'"   
-        [9] "     and standard deviation equal to 'sd'."                              
-       [10] ""                                                                        
-       [11] "Usage:"                                                                  
-       [12] ""                                                                        
-       [13] "     dnorm(x, mean = 0, sd = 1, log = FALSE)"                            
-       [14] "     pnorm(q, mean = 0, sd = 1, lower.tail = TRUE, log.p = FALSE)"       
-       [15] "     qnorm(p, mean = 0, sd = 1, lower.tail = TRUE, log.p = FALSE)"       
-       [16] "     rnorm(n, mean = 0, sd = 1)"                                         
-       [17] "     "                                                                   
-       [18] "Arguments:"                                                              
-       [19] ""                                                                        
-       [20] "    x, q: vector of quantiles."                                          
-       [21] ""                                                                        
-       [22] "       p: vector of probabilities."                                      
-       [23] ""                                                                        
-       [24] "       n: number of observations. If 'length(n) > 1', the length is"     
-       [25] "          taken to be the number required."                              
-       [26] ""                                                                        
-       [27] "    mean: vector of means."                                              
-       [28] ""                                                                        
-       [29] "      sd: vector of standard deviations."                                
-       [30] ""                                                                        
-       [31] "log, log.p: logical; if TRUE, probabilities p are given as log(p)."      
-       [32] ""                                                                        
-       [33] "lower.tail: logical; if TRUE (default), probabilities are P[X <= x]"     
-       [34] "          otherwise, P[X > x]."                                          
-       [35] ""                                                                        
-       [36] "Details:"                                                                
-       [37] ""                                                                        
-       [38] "     If 'mean' or 'sd' are not specified they assume the default values" 
-       [39] "     of '0' and '1', respectively."                                      
-       [40] ""                                                                        
-       [41] "     The normal distribution has density"                                
-       [42] ""                                                                        
-       [43] "           f(x) = 1/(sqrt(2 pi) sigma) e^-((x - mu)^2/(2 sigma^2))      "
-       [44] "     "                                                                   
-       [45] "     where mu is the mean of the distribution and sigma the standard"    
-       [46] "     deviation."                                                         
-       [47] ""                                                                        
-       [48] "Value:"                                                                  
-       [49] ""                                                                        
-       [50] "     'dnorm' gives the density, 'pnorm' gives the distribution"          
-       [51] "     function, 'qnorm' gives the quantile function, and 'rnorm'"         
-       [52] "     generates random deviates."                                         
-       [53] ""                                                                        
-       [54] "     The length of the result is determined by 'n' for 'rnorm', and is"  
-       [55] "     the maximum of the lengths of the numerical arguments for the"      
-       [56] "     other functions."                                                   
-       [57] ""                                                                        
-       [58] "     The numerical arguments other than 'n' are recycled to the length"  
-       [59] "     of the result.  Only the first elements of the logical arguments"   
-       [60] "     are used."                                                          
-       [61] ""                                                                        
-       [62] "     For 'sd = 0' this gives the limit as 'sd' decreases to 0, a point"  
-       [63] "     mass at 'mu'.  'sd < 0' is an error and returns 'NaN'."             
-       [64] ""                                                                        
-       [65] "Source:"                                                                 
-       [66] ""                                                                        
-       [67] "     For 'pnorm', based on"                                              
-       [68] ""                                                                        
-       [69] "     Cody, W. D. (1993) Algorithm 715: SPECFUN - A portable FORTRAN"     
-       [70] "     package of special function routines and test drivers.  _ACM"       
-       [71] "     Transactions on Mathematical Software_ *19*, 22-32."                
-       [72] ""                                                                        
-       [73] "     For 'qnorm', the code is based on a C translation of"               
-       [74] ""                                                                        
-       [75] "     Wichura, M. J. (1988) Algorithm AS 241: The percentage points of"   
-       [76] "     the normal distribution.  _Applied Statistics_, *37*, 477-484;"     
-       [77] "     doi:10.2307/2347330 <https://doi.org/10.2307/2347330>."             
-       [78] ""                                                                        
-       [79] "     which provides precise results up to about 16 digits for"           
-       [80] "     'log.p=FALSE'.  For log scale probabilities in the extreme tails,"  
-       [81] "     since R version 4.1.0, extensively since 4.3.0, asymptotic"         
-       [82] "     expansions are used which have been derived and explored in"        
-       [83] ""                                                                        
-       [84] "     Maechler, M. (2022) Asymptotic tail formulas for gaussian"          
-       [85] "     quantiles; 'DPQ' vignette"                                          
-       [86] "     <https://CRAN.R-project.org/package=DPQ/vignettes/qnorm-asymp.pdf>."
-       [87] ""                                                                        
-       [88] "     For 'rnorm', see RNG for how to select the algorithm and for"       
-       [89] "     references to the supplied methods."                                
-       [90] ""                                                                        
-       [91] "References:"                                                             
-       [92] ""                                                                        
-       [93] "     Becker, R. A., Chambers, J. M. and Wilks, A. R. (1988) _The New S"  
-       [94] "     Language_.  Wadsworth & Brooks/Cole."                               
-       [95] ""                                                                        
-       [96] "     Johnson, N. L., Kotz, S. and Balakrishnan, N. (1995) _Continuous"   
-       [97] "     Univariate Distributions_, volume 1, chapter 13.  Wiley, New York." 
-       [98] ""                                                                        
-       [99] "See Also:"                                                               
-      [100] ""                                                                        
-      [101] "     Distributions for other standard distributions, including 'dlnorm'" 
-      [102] "     for the _Log_normal distribution."                                  
-      [103] ""                                                                        
-      [104] "Examples:"                                                               
-      [105] ""                                                                        
-      [106] "     require(graphics)"                                                  
-      [107] "     "                                                                   
-      [108] "     dnorm(0) == 1/sqrt(2*pi)"                                           
-      [109] "     dnorm(1) == exp(-1/2)/sqrt(2*pi)"                                   
-      [110] "     dnorm(1) == 1/sqrt(2*pi*exp(1))"                                    
-      [111] "     "                                                                   
-      [112] "     ## Using \"log = TRUE\" for an extended range :"                    
-      [113] "     par(mfrow = c(2,1))"                                                
-      [114] "     plot(function(x) dnorm(x, log = TRUE), -60, 50,"                    
-      [115] "          main = \"log { Normal density }\")"                            
-      [116] "     curve(log(dnorm(x)), add = TRUE, col = \"red\", lwd = 2)"           
-      [117] "     mtext(\"dnorm(x, log=TRUE)\", adj = 0)"                             
-      [118] "     mtext(\"log(dnorm(x))\", col = \"red\", adj = 1)"                   
-      [119] "     "                                                                   
-      [120] "     plot(function(x) pnorm(x, log.p = TRUE), -50, 10,"                  
-      [121] "          main = \"log { Normal Cumulative }\")"                         
-      [122] "     curve(log(pnorm(x)), add = TRUE, col = \"red\", lwd = 2)"           
-      [123] "     mtext(\"pnorm(x, log=TRUE)\", adj = 0)"                             
-      [124] "     mtext(\"log(pnorm(x))\", col = \"red\", adj = 1)"                   
-      [125] "     "                                                                   
-      [126] "     ## if you want the so-called 'error function'"                      
-      [127] "     erf <- function(x) 2 * pnorm(x * sqrt(2)) - 1"                      
-      [128] "     ## (see Abramowitz and Stegun 29.2.29)"                             
-      [129] "     ## and the so-called 'complementary error function'"                
-      [130] "     erfc <- function(x) 2 * pnorm(x * sqrt(2), lower = FALSE)"          
-      [131] "     ## and the inverses"                                                
-      [132] "     erfinv <- function (x) qnorm((1 + x)/2)/sqrt(2)"                    
-      [133] "     erfcinv <- function (x) qnorm(x/2, lower = FALSE)/sqrt(2)"          
-      [134] "     "                                                                   
+      ## `help(package = "stats", "rnorm")`
+      
+      ### The Normal Distribution
+      
+      #### Description
+      
+      Density, distribution function, quantile function and random generation
+      for the normal distribution with mean equal to `mean` and standard
+      deviation equal to `sd`.
+      
+      #### Usage
+      
+      ``` R
+      dnorm(x, mean = 0, sd = 1, log = FALSE)
+      pnorm(q, mean = 0, sd = 1, lower.tail = TRUE, log.p = FALSE)
+      qnorm(p, mean = 0, sd = 1, lower.tail = TRUE, log.p = FALSE)
+      rnorm(n, mean = 0, sd = 1)
+      ```
+      
+      #### Arguments
+      
+      |  |  |
+      |----|----|
+      | `x`, `q` | vector of quantiles. |
+      | `p` | vector of probabilities. |
+      | `n` | number of observations. If `length(n) > 1`, the length is taken to be the number required. |
+      | `mean` | vector of means. |
+      | `sd` | vector of standard deviations. |
+      | `log`, `log.p` | logical; if TRUE, probabilities p are given as log(p). |
+      | `lower.tail` | logical; if TRUE (default), probabilities are `P[X \le x]` otherwise, `P[X > x]`. |
+      
+      #### Details
+      
+      If `mean` or `sd` are not specified they assume the default values of
+      `0` and `1`, respectively.
+      
+      The normal distribution has density
+      
+      ` f(x) = \frac{1}{\sqrt{2\pi}\sigma} e^{-(x-\mu)^2/2\sigma^2}`
+      
+      where `\mu` is the mean of the distribution and `\sigma` the standard
+      deviation.
+      
+      #### Value
+      
+      `dnorm` gives the density, `pnorm` gives the distribution function,
+      `qnorm` gives the quantile function, and `rnorm` generates random
+      deviates.
+      
+      The length of the result is determined by `n` for `rnorm`, and is the
+      maximum of the lengths of the numerical arguments for the other
+      functions.
+      
+      The numerical arguments other than `n` are recycled to the length of the
+      result. Only the first elements of the logical arguments are used.
+      
+      For `sd = 0` this gives the limit as `sd` decreases to 0, a point mass
+      at `mu`. `sd < 0` is an error and returns `NaN`.
+      
+      #### Source
+      
+      For `pnorm`, based on
+      
+      Cody, W. D. (1993) Algorithm 715: SPECFUN – A portable FORTRAN package
+      of special function routines and test drivers. *ACM Transactions on
+      Mathematical Software* **19**, 22–32.
+      
+      For `qnorm`, the code is based on a C translation of
+      
+      Wichura, M. J. (1988) Algorithm AS 241: The percentage points of the
+      normal distribution. *Applied Statistics*, **37**, 477–484;
+      [doi:10.2307/2347330](https://doi.org/10.2307/2347330).
+      
+      which provides precise results up to about 16 digits for `log.p=FALSE`.
+      For log scale probabilities in the extreme tails, since
+      <span class="rlang">**R**</span> version 4.1.0, extensively since 4.3.0,
+      asymptotic expansions are used which have been derived and explored in
+      
+      Maechler, M. (2022) Asymptotic tail formulas for gaussian quantiles;
+      [<span class="pkg">DPQ</span>](https://CRAN.R-project.org/package=DPQ)
+      vignette
+      <https://CRAN.R-project.org/package=DPQ/vignettes/qnorm-asymp.pdf>.
+      
+      For `rnorm`, see RNG for how to select the algorithm and for references
+      to the supplied methods.
+      
+      #### References
+      
+      Becker, R. A., Chambers, J. M. and Wilks, A. R. (1988) *The New S
+      Language*. Wadsworth & Brooks/Cole.
+      
+      Johnson, N. L., Kotz, S. and Balakrishnan, N. (1995) *Continuous
+      Univariate Distributions*, volume 1, chapter 13. Wiley, New York.
+      
+      #### See Also
+      
+      Distributions for other standard distributions, including `dlnorm` for
+      the *Log*normal distribution.
+      
+      #### Examples
+      
+      ``` R
+      require(graphics)
+      
+      dnorm(0) == 1/sqrt(2*pi)
+      dnorm(1) == exp(-1/2)/sqrt(2*pi)
+      dnorm(1) == 1/sqrt(2*pi*exp(1))
+      
+      ## Using "log = TRUE" for an extended range :
+      par(mfrow = c(2,1))
+      plot(function(x) dnorm(x, log = TRUE), -60, 50,
+           main = "log { Normal density }")
+      curve(log(dnorm(x)), add = TRUE, col = "red", lwd = 2)
+      mtext("dnorm(x, log=TRUE)", adj = 0)
+      mtext("log(dnorm(x))", col = "red", adj = 1)
+      
+      plot(function(x) pnorm(x, log.p = TRUE), -50, 10,
+           main = "log { Normal Cumulative }")
+      curve(log(pnorm(x)), add = TRUE, col = "red", lwd = 2)
+      mtext("pnorm(x, log=TRUE)", adj = 0)
+      mtext("log(pnorm(x))", col = "red", adj = 1)
+      
+      ## if you want the so-called 'error function'
+      erf <- function(x) 2 * pnorm(x * sqrt(2)) - 1
+      ## (see Abramowitz and Stegun 29.2.29)
+      ## and the so-called 'complementary error function'
+      erfc <- function(x) 2 * pnorm(x * sqrt(2), lower = FALSE)
+      ## and the inverses
+      erfinv <- function (x) qnorm((1 + x)/2)/sqrt(2)
+      erfcinv <- function (x) qnorm(x/2, lower = FALSE)/sqrt(2)
+      ```
 

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -1,7 +1,7 @@
 use_latest_pandoc <- function(.envir = parent.frame()) {
   v <- Sys.getenv("BTW_TESTS_PANDOC_VERSION", "latest")
   if (identical(v, "latest")) {
-    v <- pandoc::pandoc_available_releases()[1]
+    v <- suppressMessages(pandoc::pandoc_available_releases()[1])
   }
   if (!pandoc::pandoc_is_installed(v)) {
     pandoc::pandoc_install(v)

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -1,3 +1,14 @@
+use_latest_pandoc <- function(.envir = parent.frame()) {
+  v <- Sys.getenv("BTW_TESTS_PANDOC_VERSION", "latest")
+  if (identical(v, "latest")) {
+    v <- pandoc::pandoc_available_releases()[1]
+  }
+  if (!pandoc::pandoc_is_installed(v)) {
+    pandoc::pandoc_install(v)
+  }
+  pandoc::pandoc_activate(v, quiet = TRUE)
+}
+
 skip_if_not_macos <- function() {
   # Skip helper: snapshots only on macos for now
   skip_on_os("windows")

--- a/tests/testthat/test-btw_this.R
+++ b/tests/testthat/test-btw_this.R
@@ -1,3 +1,5 @@
+use_latest_pandoc()
+
 test_that("btw_this.function()", {
   skip_if_not_macos()
   expect_snapshot(cli::cat_line(btw_this(dplyr::mutate)))

--- a/tests/testthat/test-tool-docs.R
+++ b/tests/testthat/test-tool-docs.R
@@ -12,7 +12,7 @@ test_that("btw_tool_docs_help_page() works", {
 
   res <- btw_tool_docs_help_page(package_name = "stats", topic = "rnorm")
 
-  expect_snapshot(res)
+  expect_snapshot(cli::cat_line(res))
 })
 
 test_that("btw_tool_docs_available_vignettes() works", {

--- a/tests/testthat/test-tool-docs.R
+++ b/tests/testthat/test-tool-docs.R
@@ -1,3 +1,5 @@
+use_latest_pandoc()
+
 test_that("btw_tool_docs_package_help_topics() works", {
   res <- btw_tool_docs_package_help_topics("stats")
 


### PR DESCRIPTION
Smallish rewrite of `btw_tool_docs_help_page()` to use `tools::Rd2html()` and `pandoc` to make the help page docs.

Fixes #48 along the way:

```r
client <- btw_client()
#> Using model = "claude-3-7-sonnet-latest".

client$chat("What's in the help topic for `promise`?")
#> I'll check the help page for the `promise` function in R for you.
#> ◯ [tool call] btw_tool_docs_help_page(package_name = "", topic = "promise")
#> ● #> Topic 'promise' matched 2 different topics. Please ask the user to choose one of the following:
#>   #> {{"topic":"promise", "package_name":"promises"}}
#>   #> {{"topic":"delayedAssign", "package_name":"base"}}
#> I found that the topic "promise" matches two different help pages in R:
#> 
#> 1. `promise` in the `promises` package
#> 2. `delayedAssign` in the `base` package (which includes information about promises)
#> 
#> Which one would you like me to look up for you?

client$chat("1")
#> I'll look up the help page for the `promise` function in the `promises` package for you.
#> ◯ [tool call] btw_tool_docs_help_page(package_name = "promises", topic = "promise")
#> ● #> ## `help(package = "promises", "promise")`
#>   #>
#>   #> ### Create a new promise object
#>   #>
#>   #> #### Description
#>   #> …
#> # Help Page for `promise` (promises package)
#> 
#> ## Description
#> The `promise()` function creates a new promise object in R, which serves as a placeholder for the eventual result (or 
#> error) of an asynchronous operation. This function is primarily intended for package authors who want to write asynchronous
#> functions that return promises.
#> [...snip...]
```

My hope is that this approach gets us a little closer to being able to extract just the examples, or other parts of the Rd file, because we're now working with `tools::parseRd()`