### PR TITLE
return _both_ vignette and reference for `btw("{pkg})")`

### DIFF
--- a/R/btw_this.R
+++ b/R/btw_this.R
@@ -169,13 +169,9 @@ btw_this.character <- function(x, ..., caller_env = parent.frame()) {
     # * use only letters, numbers or .
     # * be two or more characters long
     pkg <- substring(x, 2, nchar(x) - 1)
-    res <- btw_tool_docs_package_help_topics(pkg)
-    tryCatch(
-      # Get the package vignette
-      res <- c(btw_tool_docs_vignette(pkg), "", res),
-      error = function(err) {
-        character(0)
-      }
+    res <- c(
+      btw_tool_docs_package_help_topics(pkg),
+      tryCatch(c("", btw_tool_docs_vignette(pkg)), error = function(e) NULL)
     )
     return(res)
   }

--- a/R/btw_this.R
+++ b/R/btw_this.R
@@ -63,13 +63,12 @@ as_btw_capture <- function(x) {
 #'     file.
 #'
 #' * `"{pkgName}"` \cr
-#'   A package name wrapped in braces. Returns either the
-#'   introductory vignette for the package
-#'   ([btw_tool_docs_vignette()]) or a list of help topics if no
-#'   such vignette exists ([btw_tool_docs_package_help_topics()]).
+#'   A package name wrapped in braces. Returns list of help topics 
+#'   ([btw_tool_docs_package_help_topics()]) and if it exists, the
+#'   introductory vignette for the package ([btw_tool_docs_vignette()]).
 #'
 #'   * `btw_this("{dplyr}")` includes dplyr's introductory vignette.
-#'   * `btw_this("{btw}")` returns the package help index (because `btw`
+#'   * `btw_this("{btw}")` returns only the package help index (because `btw`
 #'     doesn't have an intro vignette, yet).
 #'
 #' * `"?help_topic"` \cr
@@ -170,12 +169,12 @@ btw_this.character <- function(x, ..., caller_env = parent.frame()) {
     # * use only letters, numbers or .
     # * be two or more characters long
     pkg <- substring(x, 2, nchar(x) - 1)
-    res <- tryCatch(
+    res <- btw_tool_docs_package_help_topics(pkg)
+    tryCatch(
       # Get the package vignette
-      btw_tool_docs_vignette(pkg),
+      res <- c(btw_tool_docs_vignette(pkg), "", res),
       error = function(err) {
-        # or list help topics
-        btw_tool_docs_package_help_topics(pkg)
+        character(0)
       }
     )
     return(res)

--- a/R/btw_this.R
+++ b/R/btw_this.R
@@ -63,8 +63,8 @@ as_btw_capture <- function(x) {
 #'     file.
 #'
 #' * `"{pkgName}"` \cr
-#'   A package name wrapped in braces. Returns list of help topics 
-#'   ([btw_tool_docs_package_help_topics()]) and if it exists, the
+#'   A package name wrapped in braces. Returns the list of help topics 
+#'   ([btw_tool_docs_package_help_topics()]) and, if it exists, the
 #'   introductory vignette for the package ([btw_tool_docs_vignette()]).
 #'
 #'   * `btw_this("{dplyr}")` includes dplyr's introductory vignette.

--- a/man/btw_this.character.Rd
+++ b/man/btw_this.character.Rd
@@ -34,13 +34,12 @@ is a directory we call \code{\link[=btw_tool_files_list_files]{btw_tool_files_li
 file.
 }
 \item \code{"{pkgName}"} \cr
-A package name wrapped in braces. Returns either the
-introductory vignette for the package
-(\code{\link[=btw_tool_docs_vignette]{btw_tool_docs_vignette()}}) or a list of help topics if no
-such vignette exists (\code{\link[=btw_tool_docs_package_help_topics]{btw_tool_docs_package_help_topics()}}).
+A package name wrapped in braces. Returns list of help topics
+(\code{\link[=btw_tool_docs_package_help_topics]{btw_tool_docs_package_help_topics()}}) and if it exists, the
+introductory vignette for the package (\code{\link[=btw_tool_docs_vignette]{btw_tool_docs_vignette()}}).
 \itemize{
 \item \code{btw_this("{dplyr}")} includes dplyr's introductory vignette.
-\item \code{btw_this("{btw}")} returns the package help index (because \code{btw}
+\item \code{btw_this("{btw}")} returns only the package help index (because \code{btw}
 doesn't have an intro vignette, yet).
 }
 \item \code{"?help_topic"} \cr

--- a/man/btw_this.character.Rd
+++ b/man/btw_this.character.Rd
@@ -34,8 +34,8 @@ is a directory we call \code{\link[=btw_tool_files_list_files]{btw_tool_files_li
 file.
 }
 \item \code{"{pkgName}"} \cr
-A package name wrapped in braces. Returns list of help topics
-(\code{\link[=btw_tool_docs_package_help_topics]{btw_tool_docs_package_help_topics()}}) and if it exists, the
+A package name wrapped in braces. Returns the list of help topics
+(\code{\link[=btw_tool_docs_package_help_topics]{btw_tool_docs_package_help_topics()}}) and, if it exists, the
 introductory vignette for the package (\code{\link[=btw_tool_docs_vignette]{btw_tool_docs_vignette()}}).
 \itemize{
 \item \code{btw_this("{dplyr}")} includes dplyr's introductory vignette.

--- a/tests/testthat/test-btw_this.R
+++ b/tests/testthat/test-btw_this.R
@@ -9,7 +9,11 @@ test_that("btw_this('{pkg}')", {
   # Gets the intro vignette if one is available
   expect_equal(
     btw_this("{dplyr}"),
-    btw_tool_docs_vignette("dplyr")
+    c(
+      btw_tool_docs_vignette("dplyr"),
+      "",
+      btw_tool_docs_package_help_topics("dplyr")
+    )
   )
 
   # Otherwise returns the help index

--- a/tests/testthat/test-btw_this.R
+++ b/tests/testthat/test-btw_this.R
@@ -10,9 +10,9 @@ test_that("btw_this('{pkg}')", {
   expect_equal(
     btw_this("{dplyr}"),
     c(
-      btw_tool_docs_vignette("dplyr"),
+      btw_tool_docs_package_help_topics("dplyr"),
       "",
-      btw_tool_docs_package_help_topics("dplyr")
+      btw_tool_docs_vignette("dplyr")
     )
   )
 


### PR DESCRIPTION
Closes #51.

Went the route of transitioning to supplying both the vignette and reference rather than just updating the verbiage in the README, but I understand if you feel the latter is the way to go.