### PR TITLE
feat: Use `~/btw.md` by default

### DIFF
--- a/R/btw_client.R
+++ b/R/btw_client.R
@@ -57,6 +57,12 @@
 #' when your system prompt contains notes to yourself or future tasks that you
 #' do not want to be included in the system prompt.
 #'
+#' For project-specific configuration, store your `btw.md` file in the root of
+#' your project directory. For global configuration, you can maintain a `btw.md`
+#' file in your home directory (at `fs::path_home("btw.md")` or
+#' `fs::path_home_r("btw.md")`). This file will be used by default when a
+#' project-specific `btw.md` file is not found.
+#'
 #' ## Client Options
 #'
 #' * `btw.client`: The [ellmer::Chat] client to use as the basis for new
@@ -340,7 +346,9 @@ btw_app <- function(..., client = NULL, tools = NULL, path_btw = NULL) {
 btw_tools_df <- function() {
   .btw_tools <- map(.btw_tools, function(def) {
     tool <- def$tool()
-    if (is.null(tool)) return()
+    if (is.null(tool)) {
+      return()
+    }
     dplyr::tibble(
       group = def$group,
       name = tool@name,
@@ -487,7 +495,7 @@ btw_client_config <- function(client = NULL, tools = NULL, config = list()) {
 read_btw_file <- function(path = NULL) {
   must_find <- !is.null(path)
 
-  path <- path %||% path_find_in_project("btw.md")
+  path <- path %||% path_find_in_project("btw.md") %||% path_find_user("btw.md")
 
   if (!must_find && is.null(path)) {
     return(list())
@@ -510,7 +518,9 @@ read_btw_file <- function(path = NULL) {
 }
 
 remove_hidden_content <- function(lines) {
-  if (length(lines) == 0) return(character(0))
+  if (length(lines) == 0) {
+    return(character(0))
+  }
 
   starts <- cumsum(trimws(lines) == "<!-- HIDE -->")
   ends <- trimws(lines) == "<!-- /HIDE -->"

--- a/R/btw_client.R
+++ b/R/btw_client.R
@@ -59,8 +59,8 @@
 #'
 #' For project-specific configuration, store your `btw.md` file in the root of
 #' your project directory. For global configuration, you can maintain a `btw.md`
-#' file in your home directory (at `fs::path_home("btw.md")` or
-#' `fs::path_home_r("btw.md")`). This file will be used by default when a
+#' file in your home directory (at `btw.md` or `.config/btw/btw.md` in your home
+#' directory, using `fs::path_home()`). This file will be used by default when a
 #' project-specific `btw.md` file is not found.
 #'
 #' ## Client Options

--- a/R/tool-data-frame.R
+++ b/R/tool-data-frame.R
@@ -270,7 +270,9 @@ describe_data_frame_skim <- function(df) {
         col$values <- values[seq_len(min(length(values), 10))]
       }
       col$values <- vapply(col$values, FUN.VALUE = character(1), function(x) {
-        if (is.na(x) || nchar(x) <= 140) return(x)
+        if (is.na(x) || nchar(x) <= 140) {
+          return(x)
+        }
         paste(substring(x, 1, 140), "...")
       })
     } else if (col$type == "factor") {

--- a/R/tool-environment.R
+++ b/R/tool-environment.R
@@ -175,6 +175,8 @@ btw_item_with_description <- function(item_name, description, header = NULL) {
     item_name <- NULL
   }
 
-  if (!is.null(header)) header <- c(header, "")
+  if (!is.null(header)) {
+    header <- c(header, "")
+  }
   paste(c(header, item_name, description), collapse = "\n")
 }

--- a/R/tool-rstudioapi.R
+++ b/R/tool-rstudioapi.R
@@ -58,7 +58,9 @@ btw_tool_ide_read_current_editor <- function(
     )
   } else {
     for (selection in cf$selection) {
-      if (!nzchar(selection$text)) next
+      if (!nzchar(selection$text)) {
+        next
+      }
 
       line_column <- function(range) {
         sprintf("L%dC%d", range[1], range[2])
@@ -95,7 +97,9 @@ BtwEditorContextToolResult <- S7::new_class(
   name = "btw_tool_ide_read_current_editor",
   group = "ide",
   tool = function() {
-    if (!rstudioapi_has_source_editor_context()) return(NULL)
+    if (!rstudioapi_has_source_editor_context()) {
+      return(NULL)
+    }
     ellmer::tool(
       btw_tool_ide_read_current_editor,
       .description = paste(

--- a/R/tool-search-packages.R
+++ b/R/tool-search-packages.R
@@ -246,8 +246,11 @@ btw_this.cran_package <- function(x, ...) {
       if (dep_name == "R") {
         return(paste0("* R ", deps[[dep_name]]))
       } else {
-        ver <- if (deps[[dep_name]] == "*") "" else
+        ver <- if (deps[[dep_name]] == "*") {
+          ""
+        } else {
           paste0(" (", deps[[dep_name]], ")")
+        }
         return(paste0("* ", dep_name, ver))
       }
     })

--- a/R/tool-sessioninfo.R
+++ b/R/tool-sessioninfo.R
@@ -128,8 +128,12 @@ btw_tool_session_package_info <- function(
   }
 
   string_with_comma <- function(x) {
-    if (!is.character(x)) return(FALSE)
-    if (length(x) != 1) return(FALSE)
+    if (!is.character(x)) {
+      return(FALSE)
+    }
+    if (length(x) != 1) {
+      return(FALSE)
+    }
     grepl(",", x, fixed = TRUE)
   }
 

--- a/R/tools.R
+++ b/R/tools.R
@@ -67,10 +67,18 @@ btw_tools <- function(tools = NULL) {
 }
 
 is_tool_match <- function(tool, labels = NULL) {
-  if (is.null(labels)) return(TRUE)
-  if (tool$name %in% labels) return(TRUE)
-  if (tool$group %in% labels) return(TRUE)
-  if (sub("btw_tool_", "", tool$name) %in% labels) return(TRUE)
+  if (is.null(labels)) {
+    return(TRUE)
+  }
+  if (tool$name %in% labels) {
+    return(TRUE)
+  }
+  if (tool$group %in% labels) {
+    return(TRUE)
+  }
+  if (sub("btw_tool_", "", tool$name) %in% labels) {
+    return(TRUE)
+  }
   FALSE
 }
 
@@ -82,7 +90,9 @@ as_ellmer_tools <- function(x) {
 }
 
 wrap_with_intent <- function(tool) {
-  if ("intent" %in% names(tool@arguments@properties)) return(tool)
+  if ("intent" %in% names(tool@arguments@properties)) {
+    return(tool)
+  }
 
   tool_fun <- tool@fun
   wrapped_tool <- new_function(

--- a/R/utils.R
+++ b/R/utils.R
@@ -101,7 +101,8 @@ path_find_user <- function(filename) {
 
   possibilities <- c(
     fs::path_home(filename),
-    fs::path_home_r(filename)
+    fs::path_home_r(filename),
+    fs::path_home(".config", "btw", filename)
   )
 
   for (path in possibilities) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -86,9 +86,31 @@ path_find_in_project <- function(filename, dir = getwd()) {
     length(dir(pattern = ".[.]Rproj$")) > 0 ||
     dirname(dir) == dir
 
-  if (at_project_root) return(NULL)
+  if (at_project_root) {
+    return(NULL)
+  }
 
   path_find_in_project(filename, dirname(dir))
+}
+
+path_find_user <- function(filename) {
+  if (identical(Sys.getenv("TESTTHAT"), "true")) {
+    # In testthat, we don't want to use the home directory
+    return(NULL)
+  }
+
+  possibilities <- c(
+    fs::path_home(filename),
+    fs::path_home_r(filename)
+  )
+
+  for (path in possibilities) {
+    if (fs::file_exists(path)) {
+      return(fs::path_norm(path))
+    }
+  }
+
+  NULL
 }
 
 local_reproducible_output <- function(

--- a/man/btw_client.Rd
+++ b/man/btw_client.Rd
@@ -89,6 +89,12 @@ them in HTML \verb{<!-- HIDE -->} and \verb{<!-- /HIDE -->} comment tags. A sing
 \verb{<!-- /HIDE -->} tag, or the end of the file. This is particularly useful
 when your system prompt contains notes to yourself or future tasks that you
 do not want to be included in the system prompt.
+
+For project-specific configuration, store your \code{btw.md} file in the root of
+your project directory. For global configuration, you can maintain a \code{btw.md}
+file in your home directory (at \code{fs::path_home("btw.md")} or
+\code{fs::path_home_r("btw.md")}). This file will be used by default when a
+project-specific \code{btw.md} file is not found.
 }
 
 \subsection{Client Options}{

--- a/man/btw_client.Rd
+++ b/man/btw_client.Rd
@@ -92,8 +92,8 @@ do not want to be included in the system prompt.
 
 For project-specific configuration, store your \code{btw.md} file in the root of
 your project directory. For global configuration, you can maintain a \code{btw.md}
-file in your home directory (at \code{fs::path_home("btw.md")} or
-\code{fs::path_home_r("btw.md")}). This file will be used by default when a
+file in your home directory (at \code{btw.md} or \code{.config/btw/btw.md} in your home
+directory, using \code{fs::path_home()}). This file will be used by default when a
 project-specific \code{btw.md} file is not found.
 }
 


### PR DESCRIPTION
Fixes #36

Looks for `~/btw.md` or `~/.config/btw/btw.md` if a project-specific `btw.md` wasn't found. Is disabled during testing with `testthat`.