### PR TITLE
transition to ellmer 0.3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Imports:
     cli,
     clipr,
     dplyr,
-    ellmer (>= 0.2.0),
+    ellmer (>= 0.2.1.9000),
     fs,
     jsonlite,
     lifecycle,
@@ -50,7 +50,8 @@ Suggests:
     shinychat (>= 0.2.0),
     testthat (>= 3.0.0)
 Remotes:
-    posit-dev/mcptools
+    posit-dev/mcptools,
+    tidyverse/ellmer
 Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Config/testthat/parallel: true

--- a/R/tool-data-frame.R
+++ b/R/tool-data-frame.R
@@ -170,48 +170,50 @@ get_dataset_from_package <- function(name, package = NULL) {
   tool = function() {
     ellmer::tool(
       btw_tool_env_describe_data_frame,
-      .name = "btw_tool_env_describe_data_frame",
-      .description = "Show the data frame or table or get information about the structure of a data frame or table.",
-      .annotations = ellmer::tool_annotations(
+      name = "btw_tool_env_describe_data_frame",
+      description = "Show the data frame or table or get information about the structure of a data frame or table.",
+      annotations = ellmer::tool_annotations(
         title = "Show a data frame",
         read_only_hint = TRUE,
         open_world_hint = FALSE
       ),
-      data_frame = ellmer::type_string("The name of the data frame."),
-      package = ellmer::type_string(
-        paste(
-          "The package that provides the data set.",
-          "If not provided, `data_frame` must be loaded in the current environment."
+      arguments = list(
+        data_frame = ellmer::type_string("The name of the data frame."),
+        package = ellmer::type_string(
+          paste(
+            "The package that provides the data set.",
+            "If not provided, `data_frame` must be loaded in the current environment."
+          ),
+          required = FALSE
         ),
-        required = FALSE
-      ),
-      format = ellmer::type_enum(
-        paste(
-          "The output format of the data frame: 'skim' or 'json'. 'skim' is the most information-dense and is the default.",
-          "",
-          "* skim: Returns a JSON object with information about every column in the table.",
-          "* json: Returns the data frame as JSON",
-          sep = "\n"
+        format = ellmer::type_enum(
+          paste(
+            "The output format of the data frame: 'skim' or 'json'. 'skim' is the most information-dense and is the default.",
+            "",
+            "* skim: Returns a JSON object with information about every column in the table.",
+            "* json: Returns the data frame as JSON",
+            sep = "\n"
+          ),
+          values = c("skim", "json"),
+          required = FALSE
         ),
-        values = c("skim", "json"),
-        required = FALSE
-      ),
-      max_rows = ellmer::type_integer(
-        paste(
-          "The maximum number of rows to show in the data frame.",
-          "Defaults to 5.",
-          "Only applies when `format=\"json\"`."
+        max_rows = ellmer::type_integer(
+          paste(
+            "The maximum number of rows to show in the data frame.",
+            "Defaults to 5.",
+            "Only applies when `format=\"json\"`."
+          ),
+          required = FALSE
         ),
-        required = FALSE
-      ),
-      max_cols = ellmer::type_integer(
-        paste(
-          "The maximum number of columns to show in the data frame.",
-          "Defaults to 100.",
-          "Only applies when `format=\"json\"`."
-        ),
-        required = FALSE
-      ),
+        max_cols = ellmer::type_integer(
+          paste(
+            "The maximum number of columns to show in the data frame.",
+            "Defaults to 100.",
+            "Only applies when `format=\"json\"`."
+          ),
+          required = FALSE
+        )
+      )
     )
   }
 )

--- a/R/tool-docs-news.R
+++ b/R/tool-docs-news.R
@@ -57,7 +57,7 @@ btw_tool_docs_package_news <- function(package_name, search_term = "") {
   tool = function() {
     ellmer::tool(
       btw_tool_docs_package_news,
-      .description = paste0(
+      description = paste0(
         "Read the release notes (NEWS) for a package.",
         "\n\n",
         "Use this tool when you need to learn what changed in a package release, i.e. when code no longer works after a package update, or when the user asks to learn about new features.",
@@ -68,23 +68,25 @@ btw_tool_docs_package_news <- function(package_name, search_term = "") {
         "Use a search term to learn about recent changes to a function, feature or argument over the last few package releases. ",
         "For example, if a user recently updated a package and asks why a function no longer works, you can use this tool to find out what changed in the package release notes."
       ),
-      .annotations = ellmer::tool_annotations(
+      annotations = ellmer::tool_annotations(
         title = "Package Release Notes",
         read_only_hint = TRUE,
         open_world_hint = FALSE
       ),
-      package_name = ellmer::type_string(
-        "The name of the package.",
-        required = TRUE
-      ),
-      search_term = ellmer::type_string(
-        paste(
-          "A regular expression to use to search the NEWS entries.",
-          "Use simple regular expressions (perl style is supported).",
-          "The search term is case-insensitive.",
-          "If empty, the tool returns the release notes for the current installed version."
+      arguments = list(
+        package_name = ellmer::type_string(
+          "The name of the package.",
+          required = TRUE
         ),
-        required = FALSE
+        search_term = ellmer::type_string(
+          paste(
+            "A regular expression to use to search the NEWS entries.",
+            "Use simple regular expressions (perl style is supported).",
+            "The search term is case-insensitive.",
+            "If empty, the tool returns the release notes for the current installed version."
+          ),
+          required = FALSE
+        )
       )
     )
   }

--- a/R/tool-docs.R
+++ b/R/tool-docs.R
@@ -79,14 +79,16 @@ btw_tool_docs_package_help_topics <- function(package_name) {
   tool = function() {
     ellmer::tool(
       btw_tool_docs_package_help_topics,
-      .description = "Get available help topics for an R package.",
-      .annotations = ellmer::tool_annotations(
+      description = "Get available help topics for an R package.",
+      annotations = ellmer::tool_annotations(
         title = "Package Help Topics",
         read_only_hint = TRUE,
         open_world_hint = FALSE
       ),
-      package_name = ellmer::type_string(
-        "The exact name of the package, e.g. \"shiny\"."
+      arguments = list(
+        package_name = ellmer::type_string(
+          "The exact name of the package, e.g. \"shiny\"."
+        )
       )
     )
   }
@@ -272,17 +274,20 @@ format_help_page_text <- function(help_page) {
   tool = function() {
     ellmer::tool(
       btw_tool_docs_help_page,
-      .description = "Get help page from package.",
-      .annotations = ellmer::tool_annotations(
+      name = "btw_tool_docs_help_page",
+      description = "Get help page from package.",
+      annotations = ellmer::tool_annotations(
         title = "Help Page",
         read_only_hint = TRUE,
         open_world_hint = FALSE
       ),
-      package_name = ellmer::type_string(
-        "The exact name of the package, e.g. 'shiny'. Can be an empty string to search for a help topic across all packages."
-      ),
-      topic = ellmer::type_string(
-        "The topic_id or alias of the help page, e.g. 'withProgress' or 'incProgress'."
+      arguments = list(
+        package_name = ellmer::type_string(
+          "The exact name of the package, e.g. 'shiny'. Can be an empty string to search for a help topic across all packages."
+        ),
+        topic = ellmer::type_string(
+          "The topic_id or alias of the help page, e.g. 'withProgress' or 'incProgress'."
+        )
       )
     )
   }
@@ -313,19 +318,22 @@ btw_tool_docs_available_vignettes <- function(package_name) {
   tool = function() {
     ellmer::tool(
       btw_tool_docs_available_vignettes,
-      .description = paste(
+      name = "btw_tool_docs_available_vignettes",
+      description = paste(
         "List available vignettes for an R package.",
         "Vignettes are articles describing key concepts or features of an R package.",
         "Returns the listing as a JSON array of `vignette` and `title`.",
         "To read a vignette, use `btw_tool_docs_vignette(package_name, vignette)`."
       ),
-      .annotations = ellmer::tool_annotations(
+      annotations = ellmer::tool_annotations(
         title = "Available Vignettes",
         read_only_hint = TRUE,
         open_world_hint = FALSE
       ),
-      package_name = ellmer::type_string(
-        "The exact name of the package, e.g. 'shiny'."
+      arguments = list(
+        package_name = ellmer::type_string(
+          "The exact name of the package, e.g. 'shiny'."
+        )
       )
     )
   }
@@ -364,20 +372,23 @@ btw_tool_docs_vignette <- function(
   tool = function() {
     ellmer::tool(
       btw_tool_docs_vignette,
-      .description = "Get a package vignette in plain text.",
-      .annotations = ellmer::tool_annotations(
+      name = "btw_tool_docs_vignette",
+      description = "Get a package vignette in plain text.",
+      annotations = ellmer::tool_annotations(
         title = "Vignette",
         read_only_hint = TRUE,
         open_world_hint = FALSE
       ),
-      package_name = ellmer::type_string(
-        "The exact name of the package, e.g. 'shiny'."
-      ),
-      vignette = ellmer::type_string(
-        "The name or index of the vignette to retrieve. This is optional; if you
+      arguments = list(
+        package_name = ellmer::type_string(
+          "The exact name of the package, e.g. 'shiny'."
+        ),
+        vignette = ellmer::type_string(
+          "The name or index of the vignette to retrieve. This is optional; if you
       do not provide a value, the function retrieves the introductory vignette
       for the package.",
-        required = FALSE
+          required = FALSE
+        )
       )
     )
   }

--- a/R/tool-environment.R
+++ b/R/tool-environment.R
@@ -137,16 +137,18 @@ btw_tool_env_describe_environment <- function(
   tool = function() {
     ellmer::tool(
       btw_tool_env_describe_environment,
-      .description = "List and describe items in an environment.",
-      .annotations = ellmer::tool_annotations(
+      description = "List and describe items in an environment.",
+      annotations = ellmer::tool_annotations(
         title = "Object in Session",
         read_only_hint = TRUE,
         open_world_hint = FALSE
       ),
-      items = ellmer::type_array(
-        "The names of items to describe from the environment. Defaults to `NULL`, indicating all items.",
-        items = ellmer::type_string(),
-        required = FALSE
+      arguments = list(
+        items = ellmer::type_array(
+          "The names of items to describe from the environment. Defaults to `NULL`, indicating all items.",
+          items = ellmer::type_string(),
+          required = FALSE
+        )
       )
     )
   }

--- a/R/tool-environment.R
+++ b/R/tool-environment.R
@@ -136,7 +136,9 @@ btw_tool_env_describe_environment <- function(
   group = "env",
   tool = function() {
     ellmer::tool(
-      btw_tool_env_describe_environment,
+      function(items) {
+        btw_tool_env_describe_environment(items = items)
+      },
       description = "List and describe items in an environment.",
       annotations = ellmer::tool_annotations(
         title = "Object in Session",

--- a/R/tool-files.R
+++ b/R/tool-files.R
@@ -73,7 +73,7 @@ btw_tool_files_list_files <- function(
   tool = function() {
     ellmer::tool(
       btw_tool_files_list_files,
-      .description = r"---(List files or directories in the project.
+      description = r"---(List files or directories in the project.
 
 WHEN TO USE:
 * Use this tool to discover the file structure of a project.
@@ -82,32 +82,34 @@ WHEN TO USE:
 
 CAUTION: Do not list all files in a project, instead prefer listing files in a specific directory with a `regexp` to filter to files of interest.
       )---",
-      .annotations = ellmer::tool_annotations(
+      annotations = ellmer::tool_annotations(
         title = "Project Files",
         read_only_hint = TRUE,
         open_world_hint = FALSE,
         idempotent_hint = FALSE
       ),
-      path = ellmer::type_string(
-        paste(
-          "The relative path to a folder or file.",
-          "If `path` is a directory, all files or directories (see `type`) are listed.",
-          'Use `"."` to refer to the current working directory.',
-          "If `path` is a file, information for just the selected file is listed."
+      arguments = list(
+        path = ellmer::type_string(
+          paste(
+            "The relative path to a folder or file.",
+            "If `path` is a directory, all files or directories (see `type`) are listed.",
+            'Use `"."` to refer to the current working directory.',
+            "If `path` is a file, information for just the selected file is listed."
+          ),
+          required = FALSE
         ),
-        required = FALSE
-      ),
-      type = ellmer::type_enum(
-        "Whether to list files, directories or any file type, default is `any`.",
-        values = c("any", "file", "directory"),
-        required = FALSE
-      ),
-      regexp = ellmer::type_string(
-        paste(
-          'A regular expression to use to identify files, e.g. `regexp="[.]csv$"` to find files with a `.csv` extension.',
-          "Note that it's best to be as general as possible to find the file you want."
+        type = ellmer::type_enum(
+          "Whether to list files, directories or any file type, default is `any`.",
+          values = c("any", "file", "directory"),
+          required = FALSE
         ),
-        required = FALSE
+        regexp = ellmer::type_string(
+          paste(
+            'A regular expression to use to identify files, e.g. `regexp="[.]csv$"` to find files with a `.csv` extension.',
+            "Note that it's best to be as general as possible to find the file you want."
+          ),
+          required = FALSE
+        )
       )
     )
   }
@@ -165,19 +167,22 @@ BtwTextFileToolResult <- S7::new_class(
   tool = function() {
     ellmer::tool(
       btw_tool_files_read_text_file,
-      .description = "Read an entire text file.",
-      .annotations = ellmer::tool_annotations(
+      name = "btw_tool_files_read_text_file",
+      description = "Read an entire text file.",
+      annotations = ellmer::tool_annotations(
         title = "Read File",
         read_only_hint = TRUE,
         open_world_hint = FALSE,
         idempotent_hint = FALSE
       ),
-      path = ellmer::type_string(
-        "The relative path to a file that can be read as text, such as a CSV, JSON, HTML, markdown file, etc.",
-      ),
-      max_lines = ellmer::type_number(
-        "How many lines to include from the file? The default is 100 and is likely already too high.",
-        required = FALSE
+      arguments = list(
+        path = ellmer::type_string(
+          "The relative path to a file that can be read as text, such as a CSV, JSON, HTML, markdown file, etc.",
+        ),
+        max_lines = ellmer::type_number(
+          "How many lines to include from the file? The default is 100 and is likely already too high.",
+          required = FALSE
+        )
       )
     )
   }
@@ -372,7 +377,8 @@ BtwWriteFileToolResult <- S7::new_class(
   tool = function() {
     ellmer::tool(
       btw_tool_files_write_text_file,
-      .description = 'Write content to a text file.
+      name = "btw_tool_files_write_text_file",
+      description = 'Write content to a text file.
 
 If the file doesn\'t exist, it will be created, along with any necessary parent directories.
 
@@ -385,17 +391,19 @@ CAUTION:
 This completely overwrites any existing file content.
 To modify an existing file, first read its content using `btw_tool_files_read_text_file`, make your changes to the text, then write back the complete modified content.
 ',
-      .annotations = ellmer::tool_annotations(
+      annotations = ellmer::tool_annotations(
         title = "Write File",
         read_only_hint = FALSE,
         open_world_hint = FALSE,
         idempotent_hint = TRUE
       ),
-      path = ellmer::type_string(
-        "The relative path to the file to write. The file will be created if it doesn't exist, or overwritten if it does."
-      ),
-      content = ellmer::type_string(
-        "The complete text content to write to the file."
+      arguments = list(
+        path = ellmer::type_string(
+          "The relative path to the file to write. The file will be created if it doesn't exist, or overwritten if it does."
+        ),
+        content = ellmer::type_string(
+          "The complete text content to write to the file."
+        )
       )
     )
   }

--- a/R/tool-rstudioapi.R
+++ b/R/tool-rstudioapi.R
@@ -102,28 +102,30 @@ BtwEditorContextToolResult <- S7::new_class(
     }
     ellmer::tool(
       btw_tool_ide_read_current_editor,
-      .description = paste(
+      description = paste(
         "Read the contents of the editor that is currently open in the user's IDE.",
         "Only use this tool when specifically asked to do so by the user.",
         "'@current_file' and '@current_selection' are considered explicit consent."
       ),
-      .annotations = ellmer::tool_annotations(
+      annotations = ellmer::tool_annotations(
         title = "Editor Contents",
         read_only_hint = TRUE,
         open_world_hint = FALSE,
         idempotent_hint = FALSE
       ),
-      selection = ellmer::type_boolean(
-        paste(
-          "Include only the selected region(s) of the current file?",
-          "Default is `true`; set to `false` to retrieve the entire file contents.",
-          "Always use `true` when the user requests '@current_selection'."
+      arguments = list(
+        selection = ellmer::type_boolean(
+          paste(
+            "Include only the selected region(s) of the current file?",
+            "Default is `true`; set to `false` to retrieve the entire file contents.",
+            "Always use `true` when the user requests '@current_selection'."
+          ),
+          required = FALSE
         ),
-        required = FALSE
-      ),
-      consent = ellmer::type_boolean(
-        "Did the user specifically request you read from their current file or editor?",
-        required = FALSE
+        consent = ellmer::type_boolean(
+          "Did the user specifically request you read from their current file or editor?",
+          required = FALSE
+        )
       )
     )
   }

--- a/R/tool-search-packages.R
+++ b/R/tool-search-packages.R
@@ -128,7 +128,7 @@ BtwSearchPackageToolResult <- S7::new_class(
   tool = function() {
     ellmer::tool(
       btw_tool_search_packages,
-      .description = 'Search for an R package on CRAN.
+      description = 'Search for an R package on CRAN.
 
 ## Search Behavior
 - Prioritizes exact phrase matches over individual words
@@ -144,32 +144,34 @@ BtwSearchPackageToolResult <- S7::new_class(
 Good: Search for `"permutation test"` or just `"permutation"`
 Bad: Search for `"statistical analysis tools for permutation test"`
 ',
-      .annotations = ellmer::tool_annotations(
+      annotations = ellmer::tool_annotations(
         title = "CRAN Package Search",
         read_only_hint = TRUE,
         open_world_hint = TRUE,
         idempotent_hint = FALSE
       ),
-      query = ellmer::type_string(
-        paste(
-          "The search query, e.g. \"network visualization\", \"literate programming\".",
-          "The search uses stemming to find related terms and weights phrases higher than individual terms."
+      arguments = list(
+        query = ellmer::type_string(
+          paste(
+            "The search query, e.g. \"network visualization\", \"literate programming\".",
+            "The search uses stemming to find related terms and weights phrases higher than individual terms."
+          )
+        ),
+        format = ellmer::type_string(
+          paste(
+            "The format of the search results, either \"long\" or \"short\".",
+            "Default is 'short' for discovery with a higher number of results.",
+            "Switch to \"long\" to gather more details about each package."
+          ),
+          required = FALSE
+        ),
+        n_results = ellmer::type_number(
+          paste(
+            "The number of search results to include, defaults to 20 for 'short' format and 5 for 'long' format.",
+            "Limited to 10 results for the 'long' format or 50 results for 'short' format."
+          ),
+          required = FALSE
         )
-      ),
-      format = ellmer::type_string(
-        paste(
-          "The format of the search results, either \"long\" or \"short\".",
-          "Default is 'short' for discovery with a higher number of results.",
-          "Switch to \"long\" to gather more details about each package."
-        ),
-        required = FALSE
-      ),
-      n_results = ellmer::type_number(
-        paste(
-          "The number of search results to include, defaults to 20 for 'short' format and 5 for 'long' format.",
-          "Limited to 10 results for the 'long' format or 50 results for 'short' format."
-        ),
-        required = FALSE
       )
     )
   }
@@ -291,20 +293,23 @@ btw_this.cran_package <- function(x, ...) {
   tool = function() {
     ellmer::tool(
       btw_tool_search_package_info,
-      .description = paste(
+      name = "btw_tool_search_package_info",
+      description = paste(
         "Describe a CRAN package.",
         "Shows the title, description, dependencies and author information for a package on CRAN, regardless of whether the package is installed or not."
       ),
-      .annotations = ellmer::tool_annotations(
+      annotations = ellmer::tool_annotations(
         title = "CRAN Package Info",
         read_only_hint = TRUE,
         open_world_hint = TRUE,
         idempotent_hint = FALSE
       ),
-      package_name = ellmer::type_string(
-        paste(
-          "The name of a package on CRAN.",
-          "The package does not need to be installed locally."
+      arguments = list(
+        package_name = ellmer::type_string(
+          paste(
+            "The name of a package on CRAN.",
+            "The package does not need to be installed locally."
+          )
         )
       )
     )

--- a/R/tool-session-package-installed.R
+++ b/R/tool-session-package-installed.R
@@ -43,16 +43,18 @@ btw_tool_session_check_package_installed <- function(package_name) {
   tool = function() {
     ellmer::tool(
       btw_tool_session_check_package_installed,
-      .description = "Check if a package is installed in the current session.",
-      .annotations = ellmer::tool_annotations(
+      description = "Check if a package is installed in the current session.",
+      annotations = ellmer::tool_annotations(
         title = "Package Check",
         read_only_hint = TRUE,
         open_world_hint = FALSE,
         idempotent_hint = FALSE
       ),
-      package_name = ellmer::type_string(
-        "The exact name of the package.",
-        required = TRUE
+      arguments = list(
+        package_name = ellmer::type_string(
+          "The exact name of the package.",
+          required = TRUE
+        )
       )
     )
   }

--- a/R/tool-sessioninfo.R
+++ b/R/tool-sessioninfo.R
@@ -41,15 +41,15 @@ BtwSessionInfoToolResult <- S7::new_class(
   tool = function() {
     ellmer::tool(
       btw_tool_session_platform_info,
-      .description = paste(
+      description = paste(
         "Describes the R version, operating system, language and locale settings",
         "for the user's system."
       ),
-      .annotations = ellmer::tool_annotations(
+      annotations = ellmer::tool_annotations(
         title = "Platform Info",
         read_only_hint = TRUE,
         open_world_hint = FALSE
-      ),
+      )
     )
   }
 )
@@ -196,50 +196,53 @@ package_info <- function(pkgs = NULL, dependencies = NA) {
   tool = function() {
     ellmer::tool(
       btw_tool_session_package_info,
-      .description = paste(
+      name = "btw_tool_session_package_info",
+      description = paste(
         "Verify that a specific package is installed,",
         "or find out which packages are in use in the current session.",
         "As a last resort, this function can also list all installed packages."
       ),
-      .annotations = ellmer::tool_annotations(
+      annotations = ellmer::tool_annotations(
         title = "Package Info",
         read_only_hint = TRUE,
         open_world_hint = FALSE
       ),
-      .convert = TRUE,
-      packages = ellmer::type_array(
-        required = TRUE,
-        items = ellmer::type_string(),
-        description = paste(
-          "Provide an array of package names to check that these packages are",
-          "installed and to confirm which versions of the packages are available.",
-          "Use the single string \"attached\" to show packages that have been attached by the user,",
-          "i.e. are explicitly in use in the session. Use the single string \"loaded\" to show all",
-          "packages, including implicitly loaded packages, that are in use in the",
-          "session (useful for debugging). Finally, the string \"installed\" lists all",
-          "installed packages. Try using the other available options prior to",
-          "listing all installed packages."
-        )
-      ),
-      dependencies = ellmer::type_array(
-        required = FALSE,
-        description = paste(
-          "The dependencies to include when listing package information.",
-          "You can use `dependencies = \"true\"` to list all dependencies of the package.",
-          "Alternatively, you can request an array of dependency types."
+      arguments = list(
+        packages = ellmer::type_array(
+          required = TRUE,
+          items = ellmer::type_string(),
+          description = paste(
+            "Provide an array of package names to check that these packages are",
+            "installed and to confirm which versions of the packages are available.",
+            "Use the single string \"attached\" to show packages that have been attached by the user,",
+            "i.e. are explicitly in use in the session. Use the single string \"loaded\" to show all",
+            "packages, including implicitly loaded packages, that are in use in the",
+            "session (useful for debugging). Finally, the string \"installed\" lists all",
+            "installed packages. Try using the other available options prior to",
+            "listing all installed packages."
+          )
         ),
-        items = ellmer::type_enum(
-          values = c(
-            "true",
-            "false",
-            "Depends",
-            "Imports",
-            "Suggests",
-            "LinkingTo",
-            "Enhances"
+        dependencies = ellmer::type_array(
+          required = FALSE,
+          description = paste(
+            "The dependencies to include when listing package information.",
+            "You can use `dependencies = \"true\"` to list all dependencies of the package.",
+            "Alternatively, you can request an array of dependency types."
+          ),
+          items = ellmer::type_enum(
+            values = c(
+              "true",
+              "false",
+              "Depends",
+              "Imports",
+              "Suggests",
+              "LinkingTo",
+              "Enhances"
+            )
           )
         )
-      )
+      ),
+      convert = TRUE
     )
   }
 )

--- a/R/tool-web.R
+++ b/R/tool-web.R
@@ -66,19 +66,21 @@ has_chromote <- function() {
 
     ellmer::tool(
       btw_tool_web_read_url,
-      .description = 'Read a web page and convert it to Markdown format.
+      description = 'Read a web page and convert it to Markdown format.
 
 This tool fetches the content of a web page and returns it as a simplified Markdown representation.
 
 WHEN TO USE: Use this tool when you need to access and analyze the content of a web page, e.g. when the user asks you to read the contents of a webpage.',
-      .annotations = ellmer::tool_annotations(
+      annotations = ellmer::tool_annotations(
         title = "Read Web Page",
         read_only_hint = TRUE,
         open_world_hint = TRUE,
         idempotent_hint = FALSE
       ),
-      url = ellmer::type_string(
-        "The URL of the web page to read."
+      arguments = list(
+        url = ellmer::type_string(
+          "The URL of the web page to read."
+        )
       )
     )
   }

--- a/R/tool-web.R
+++ b/R/tool-web.R
@@ -65,7 +65,9 @@ has_chromote <- function() {
     }
 
     ellmer::tool(
-      btw_tool_web_read_url,
+      function(url) {
+        btw_tool_web_read_url(url = url)
+      },
       description = 'Read a web page and convert it to Markdown format.
 
 This tool fetches the content of a web page and returns it as a simplified Markdown representation.

--- a/R/tools.R
+++ b/R/tools.R
@@ -107,12 +107,12 @@ wrap_with_intent <- function(tool) {
     return(tool)
   }
 
-  tool_fun <- tool@fun
+  tool_fun <- S7::S7_data(tool)
   wrapped_tool <- new_function(
     c(fn_fmls(tool_fun), list(intent = "")),
     fn_body(tool_fun)
   )
-  tool@fun <- wrapped_tool
+  S7::S7_data(tool) <- wrapped_tool
   tool@arguments@properties$intent <- ellmer::type_string(
     paste(
       "The intent of the tool call that describes why you called this tool.",


### PR DESCRIPTION
Address a few breaking changes in the upcoming ellmer version:

* `ellmer::tool()` argument changes
* `ellmer::tool()` no longer allows undocumented tool arguments, even if they have defaults
* `tool@fun` doesn't exist anymore